### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 env:
   AWS_REGION: us-east-2
   STACK_NAME: user-api-stack


### PR DESCRIPTION
Potential fix for [https://github.com/Somesh123-create/AWSLMBDA/security/code-scanning/1](https://github.com/Somesh123-create/AWSLMBDA/security/code-scanning/1)

To resolve this issue, we need to add an explicit `permissions` key to the root of the workflow or the specific job (`deploy`) to restrict the permissions of the `GITHUB_TOKEN` based on the principle of least privilege. Given this workflow mostly interacts with AWS and does not seem to require repository write access, we can set `contents: read` permissions globally. If specific steps or jobs require additional permissions, those can be explicitly defined.

The fix involves:
- Adding a `permissions` block at the root level to apply to all jobs.
- Setting `contents: read` to limit repository-related permissions, which is appropriate for this workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
